### PR TITLE
Initialize Expo chat assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+.dist
+.expo
+.expo-shared
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+web-build
+web-report
+.DS_Store
+*.local
+.env*
+expo-env.d.ts

--- a/App.js
+++ b/App.js
@@ -1,0 +1,217 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { StatusBar } from "expo-status-bar";
+
+const initialPrompt = "Why do you want to cancel?";
+
+export default function App() {
+  const [messages, setMessages] = useState([{ role: "agent", text: initialPrompt }]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const generatorRef = useRef(null);
+
+  const ensureGenerator = useCallback(async () => {
+    if (!generatorRef.current) {
+      const { pipeline } = await import("@xenova/transformers");
+      generatorRef.current = await pipeline("text-generation", "Xenova/distilgpt2");
+    }
+    return generatorRef.current;
+  }, []);
+
+  const conversationString = useCallback(
+    (pendingUserInput) =>
+      [...messages, ...(pendingUserInput ? [{ role: "user", text: pendingUserInput }] : [])]
+        .map((message) => `${message.role === "agent" ? "Agent" : "You"}: ${message.text}`)
+        .join("\n"),
+    [messages]
+  );
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim()) {
+      return;
+    }
+
+    const userText = input.trim();
+    setMessages((current) => [...current, { role: "user", text: userText }]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const generator = await ensureGenerator();
+      const prompt = conversationString(userText);
+      const output = await generator(prompt, {
+        max_new_tokens: 80,
+        temperature: 0.7,
+        top_p: 0.9,
+      });
+      const generated = output[0]?.generated_text ?? "";
+      const completion = generated.slice(prompt.length).trim();
+      const cleaned = completion || "I understand. Could you tell me more?";
+      setMessages((current) => [...current, { role: "agent", text: cleaned }]);
+    } catch (error) {
+      setMessages((current) => [
+        ...current,
+        {
+          role: "agent",
+          text: "I'm having trouble responding right now. Could you try again in a moment?",
+        },
+      ]);
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationString, ensureGenerator, input]);
+
+  useEffect(() => {
+    if (!messages.length) {
+      setMessages([{ role: "agent", text: initialPrompt }]);
+    }
+  }, [messages]);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={80}
+    >
+      <StatusBar style="light" />
+      <View style={styles.header}>
+        <Text style={styles.headerText}>Cancellation Assistant</Text>
+      </View>
+      <ScrollView
+        contentContainerStyle={styles.chatContainer}
+        style={styles.chat}
+        keyboardShouldPersistTaps="handled"
+      >
+        {messages.map((message, index) => (
+          <View
+            key={`${message.role}-${index}`}
+            style={[styles.message, message.role === "agent" ? styles.agentBubble : styles.userBubble]}
+          >
+            <Text style={styles.messageAuthor}>{message.role === "agent" ? "Agent" : "You"}</Text>
+            <Text style={styles.messageText}>{message.text}</Text>
+          </View>
+        ))}
+        {loading ? (
+          <View style={[styles.message, styles.agentBubble, styles.loadingBubble]}>
+            <ActivityIndicator color="#fff" />
+            <Text style={[styles.messageText, styles.loadingText]}>Agent is thinking…</Text>
+          </View>
+        ) : null}
+      </ScrollView>
+      <View style={styles.inputBar}>
+        <TextInput
+          style={styles.input}
+          placeholder="Type your response here"
+          placeholderTextColor="#aaa"
+          value={input}
+          onChangeText={setInput}
+          editable={!loading}
+          onSubmitEditing={handleSend}
+          returnKeyType="send"
+        />
+        <TouchableOpacity style={styles.sendButton} onPress={handleSend} disabled={loading}>
+          <Text style={styles.sendButtonText}>{loading ? "…" : "Send"}</Text>
+        </TouchableOpacity>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#101728",
+  },
+  header: {
+    paddingTop: 60,
+    paddingBottom: 16,
+    paddingHorizontal: 24,
+    backgroundColor: "#1f2937",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(255,255,255,0.1)",
+  },
+  headerText: {
+    color: "#f3f4f6",
+    fontSize: 20,
+    fontWeight: "600",
+  },
+  chat: {
+    flex: 1,
+  },
+  chatContainer: {
+    padding: 16,
+    gap: 12,
+  },
+  message: {
+    borderRadius: 12,
+    padding: 12,
+    maxWidth: "85%",
+  },
+  agentBubble: {
+    backgroundColor: "#2563eb",
+    alignSelf: "flex-start",
+  },
+  userBubble: {
+    backgroundColor: "#374151",
+    alignSelf: "flex-end",
+  },
+  messageAuthor: {
+    color: "rgba(255,255,255,0.8)",
+    fontSize: 12,
+    marginBottom: 4,
+    textTransform: "uppercase",
+  },
+  messageText: {
+    color: "#fff",
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  loadingBubble: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  loadingText: {
+    color: "#e0e7ff",
+    fontStyle: "italic",
+  },
+  inputBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(255,255,255,0.1)",
+    backgroundColor: "#111827",
+  },
+  input: {
+    flex: 1,
+    backgroundColor: "#1f2937",
+    color: "#f9fafb",
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: Platform.select({ ios: 12, default: 10 }),
+    marginRight: 12,
+  },
+  sendButton: {
+    backgroundColor: "#2563eb",
+    borderRadius: 999,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+  },
+  sendButtonText: {
+    color: "#fff",
+    fontWeight: "600",
+    fontSize: 16,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# click-to-cancel-2
+# Click to Cancel Assistant
+
+This project is an Expo-managed React Native application that targets the web and can be deployed to Vercel. It provides a cancellation assistant chat experience powered by the DistilGPT-2 model running directly in the browser via [`@xenova/transformers`](https://github.com/xenova/transformers.js).
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run web
+```
+
+## Building for Vercel
+
+The repository includes a `vercel.json` configuration that instructs Vercel to run the Expo web export and serve the generated static output. To create the production build locally run:
+
+```bash
+npm run build
+```
+
+The static site will be emitted to the `dist` directory, matching the `outputDirectory` defined for Vercel deployments.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,14 @@
+{
+  "expo": {
+    "name": "ClickToCancel",
+    "slug": "click-to-cancel-2",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android", "web"],
+    "assetBundlePatterns": ["**/*"],
+    "web": {
+      "bundler": "metro",
+      "output": "static"
+    }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "click-to-cancel-2",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "build": "expo export --platform web",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@xenova/transformers": "^2.12.0",
+    "expo": "~50.0.10",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.73.6",
+    "react-native-web": "~0.19.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "babel-preset-expo": "^10.0.0",
+    "eslint": "^8.56.0",
+    "eslint-config-universe": "^11.2.0"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build"
+    }
+  ],
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- scaffold an Expo-managed React Native web project with a cancellation assistant chat UI powered by DistilGPT-2 running in the browser
- add Expo configuration, Babel preset, and Vercel static build settings so the web export can deploy on Vercel
- document install, development, and build steps for deploying the exported site

## Testing
- npm install *(fails: repeated tarball corruption/403 errors in the provided registry environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d43d4f08488327b0828ccff5111151