### PR TITLE
Handle "now" cancellation date parsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,9 @@ const extractCancellationDate = (input) => {
   const lowered = trimmed.toLowerCase();
   const now = new Date();
 
+  if (lowered === "now" || /^right now$/.test(lowered)) {
+    return formatDate(now);
+  }
   if (/asap|soon|immediately/.test(lowered)) {
     return "As soon as possible";
   }


### PR DESCRIPTION
## Summary
- treat "now" or "right now" inputs for cancellation date as the current date

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d586e3a25083279ceffd8b216d6672