### PR TITLE
Add agent typing indicator with delayed responses

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -141,6 +141,15 @@ body {
   background: rgba(30, 41, 59, 0.9);
 }
 
+.chat__message--typing {
+  gap: 10px;
+}
+
+.chat__message--typing .chat__typing {
+  align-items: center;
+  min-height: 12px;
+}
+
 .chat__author {
   font-size: 0.75rem;
   text-transform: uppercase;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -378,13 +378,14 @@ export default function App() {
   }, [clearPongActivationTimeout, mode, pushMessages]);
 
   const scheduleAgentReplies = useCallback(
-    (agentReplies) => {
+    (agentReplies, options = {}) => {
       if (!agentReplies.length) {
         setIsAgentTyping(false);
         return 0;
       }
 
-      let cumulativeDelay = 0;
+      const { initialDelay = 0 } = options;
+      let cumulativeDelay = initialDelay;
       setIsAgentTyping(true);
       let lastMessageDelay = 0;
 
@@ -421,16 +422,19 @@ export default function App() {
 
   const handlePongVictory = useCallback(() => {
     clearPongActivationTimeout();
-    scheduleAgentReplies([
-      {
-        role: "agent",
-        text: "Alright, you got me—that was some sharp reflexes!",
-      },
-      {
-        role: "agent",
-        text: "I'll submit the cancellation with those details and send a confirmation to your contact on file. Is there anything else I can do for you today?",
-      },
-    ]);
+    scheduleAgentReplies(
+      [
+        {
+          role: "agent",
+          text: "Alright, you got me—that was some sharp reflexes!",
+        },
+        {
+          role: "agent",
+          text: "I'll submit the cancellation with those details and send a confirmation to your contact on file. Is there anything else I can do for you today?",
+        },
+      ],
+      { initialDelay: 900 }
+    );
     setMode(modes.completed);
   }, [clearPongActivationTimeout, scheduleAgentReplies]);
 
@@ -440,17 +444,20 @@ export default function App() {
     setStepIndex(0);
     setPendingField(null);
     setMode(modes.collecting);
-    scheduleAgentReplies([
-      {
-        role: "agent",
-        text: "Nice try! I took that round—those on-screen arrow buttons can be sneaky.",
-      },
-      {
-        role: "agent",
-        text: "Let's start fresh so I capture everything correctly.",
-      },
-      { role: "agent", text: cancellationScript[0].question },
-    ]);
+    scheduleAgentReplies(
+      [
+        {
+          role: "agent",
+          text: "Nice try! I took that round—those on-screen arrow buttons can be sneaky.",
+        },
+        {
+          role: "agent",
+          text: "Let's start fresh so I capture everything correctly.",
+        },
+        { role: "agent", text: cancellationScript[0].question },
+      ],
+      { initialDelay: 900 }
+    );
   }, [clearPongActivationTimeout, scheduleAgentReplies, setFormData, setMode, setPendingField, setStepIndex]);
 
   const scrollToEnd = useCallback(() => {
@@ -635,7 +642,7 @@ export default function App() {
       }
       if (shouldStartPongChallenge) {
         clearPongActivationTimeout();
-        const safeDelay = typeof totalDelay === "number" && totalDelay > 0 ? totalDelay + 600 : 1200;
+        const safeDelay = typeof totalDelay === "number" && totalDelay > 0 ? totalDelay + 1400 : 2000;
         pongActivationTimeoutRef.current = setTimeout(() => {
           setMode(modes.pong);
           pongActivationTimeoutRef.current = null;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -422,6 +422,7 @@ export default function App() {
 
   const handlePongVictory = useCallback(() => {
     clearPongActivationTimeout();
+    setIsAgentTyping(true);
     scheduleAgentReplies(
       [
         {
@@ -436,7 +437,7 @@ export default function App() {
       { initialDelay: 900 }
     );
     setMode(modes.completed);
-  }, [clearPongActivationTimeout, scheduleAgentReplies]);
+  }, [clearPongActivationTimeout, scheduleAgentReplies, setIsAgentTyping]);
 
   const handlePongRematch = useCallback(() => {
     clearPongActivationTimeout();
@@ -444,6 +445,7 @@ export default function App() {
     setStepIndex(0);
     setPendingField(null);
     setMode(modes.collecting);
+    setIsAgentTyping(true);
     scheduleAgentReplies(
       [
         {
@@ -458,7 +460,15 @@ export default function App() {
       ],
       { initialDelay: 900 }
     );
-  }, [clearPongActivationTimeout, scheduleAgentReplies, setFormData, setMode, setPendingField, setStepIndex]);
+  }, [
+    clearPongActivationTimeout,
+    scheduleAgentReplies,
+    setFormData,
+    setMode,
+    setPendingField,
+    setStepIndex,
+    setIsAgentTyping,
+  ]);
 
   const scrollToEnd = useCallback(() => {
     endOfMessagesRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
@@ -467,6 +477,12 @@ export default function App() {
   useEffect(() => {
     scrollToEnd();
   }, [messages, scrollToEnd]);
+
+  useEffect(() => {
+    if (isAgentTyping) {
+      scrollToEnd();
+    }
+  }, [isAgentTyping, scrollToEnd]);
 
   const handleUserMessage = useCallback(
     (rawText) => {
@@ -642,7 +658,7 @@ export default function App() {
       }
       if (shouldStartPongChallenge) {
         clearPongActivationTimeout();
-        const safeDelay = typeof totalDelay === "number" && totalDelay > 0 ? totalDelay + 1400 : 2000;
+        const safeDelay = typeof totalDelay === "number" && totalDelay > 0 ? totalDelay + 2800 : 4000;
         pongActivationTimeoutRef.current = setTimeout(() => {
           setMode(modes.pong);
           pongActivationTimeoutRef.current = null;


### PR DESCRIPTION
## Summary
- queue agent replies so they appear after a short simulated typing delay
- display an animated typing indicator while the assistant prepares a response
- update Pong follow-up flows to use the same typing experience

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d5873f88a88327b8fb0f6aec5eaad5