### PR TITLE
Add thank you closing message after cancellation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -367,6 +367,10 @@ export default function App() {
         role: "agent",
         text: "I'll submit the cancellation with those details and send a confirmation to your contact on file. Is there anything else I can do for you today?",
       },
+      {
+        role: "agent",
+        text: "Thank you for working with me today!",
+      },
     ]);
     setMode(modes.completed);
   }, [pushMessages]);


### PR DESCRIPTION
## Summary
- append a closing thank-you message after the agent confirms the cancellation to end the chat politely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d58bd26f6c8327ad5232228eb00c4a