### PR TITLE
Add start delay before pong match begins

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -236,10 +236,45 @@ body {
   justify-content: center;
 }
 
+.pong__board-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+}
+
 .pong__court {
   width: min(100%, 520px);
   height: auto;
   filter: drop-shadow(0 18px 32px rgba(15, 23, 42, 0.65));
+}
+
+.pong__ready-button {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.pong__ready-button:hover,
+.pong__ready-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px -22px rgba(59, 130, 246, 0.85);
+  border-color: rgba(96, 165, 250, 0.9);
+  outline: none;
+}
+
+.pong__ready-button:active {
+  transform: translateY(1px);
 }
 
 .pong__scoreboard {

--- a/src/PongChallenge.jsx
+++ b/src/PongChallenge.jsx
@@ -8,6 +8,7 @@ const PLAYER_X = 20;
 const AGENT_X = COURT_WIDTH - PLAYER_X - PADDLE_WIDTH;
 const BALL_SIZE = 12;
 const WINNING_SCORE = 3;
+const INITIAL_START_DELAY_MS = 1000;
 
 const AGENT_TRACKING_ZONE = COURT_WIDTH * 0.35;
 const AGENT_HESITATION_CHANCE = 0.18;
@@ -92,9 +93,19 @@ export default function PongChallenge({ onPlayerWin, onAgentWin }) {
 
   useEffect(() => {
     const state = stateRef.current;
-    state.playing = true;
+    state.playing = false;
     let animationId;
+    let startDelayId;
     let previousTime = performance.now();
+
+    const startGame = () => {
+      if (stateRef.current.playing) {
+        return;
+      }
+      stateRef.current.playing = true;
+      previousTime = performance.now();
+      animationId = requestAnimationFrame(step);
+    };
 
     const step = (time) => {
       const currentState = stateRef.current;
@@ -231,16 +242,19 @@ export default function PongChallenge({ onPlayerWin, onAgentWin }) {
         }
         resetBall(-1);
       }
-
       scheduleRender();
       animationId = requestAnimationFrame(step);
     };
 
-    animationId = requestAnimationFrame(step);
+    startDelayId = setTimeout(startGame, INITIAL_START_DELAY_MS);
+
     return () => {
       stateRef.current.playing = false;
       if (animationId) {
         cancelAnimationFrame(animationId);
+      }
+      if (startDelayId) {
+        clearTimeout(startDelayId);
       }
     };
   }, [onAgentWin, onPlayerWin, resetBall, scheduleRender]);


### PR DESCRIPTION
## Summary
- add a one second initial delay constant before the Pong loop begins to run
- start the animation frame only after the delay elapses and clean up the timer on unmount

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5938b7cb0832797cf18a82bf3538b