### PR TITLE
Add difficulty selection overlay and strict hard mode validation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,6 +98,122 @@ body {
   overflow-y: auto;
 }
 
+.mode-overlay {
+  width: min(720px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.mode-overlay__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 4vw, 1.7rem);
+  font-weight: 600;
+}
+
+.mode-overlay__subtitle {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.98rem;
+}
+
+.mode-overlay__options {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 720px) {
+  .mode-overlay__options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mode-card {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 20px;
+  padding: clamp(18px, 4vw, 26px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 22px 45px -30px rgba(37, 99, 235, 0.85);
+}
+
+.mode-card--hard {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(15, 23, 42, 0.92));
+  border-color: rgba(96, 165, 250, 0.4);
+}
+
+.mode-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mode-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(191, 219, 254, 0.7);
+}
+
+.mode-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.mode-card__highlight {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #bfdbfe;
+}
+
+.mode-card__description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.45;
+}
+
+.mode-card__details {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.mode-card__details strong {
+  color: #f8fafc;
+}
+
+.mode-card__button {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: #fff;
+  font-weight: 600;
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-size: 0.98rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.mode-card__button:hover,
+.mode-card__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px -22px rgba(37, 99, 235, 0.95);
+  border-color: rgba(191, 219, 254, 0.6);
+  outline: none;
+}
+
+.mode-card__button:active {
+  transform: translateY(1px);
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -335,6 +335,28 @@ const initialMessages = [
   { role: "agent", text: cancellationScript[0].question },
 ];
 
+const hardModeScenario = {
+  accountName: "Jordan McAllister",
+  serviceType: "Internet",
+  cancellationReason: "Relocating our headquarters to Phoenix, Arizona.",
+  cancellationDate: "May 18, 2024",
+  equipmentStatus: "Still have the modem and security gateway to return.",
+  contactMethod: "jordan.mcallister@acmecorp.com",
+};
+
+const normalizeForComparison = (key, value) => {
+  if (!value) return "";
+  let normalized = value.trim().toLowerCase().replace(/\s+/g, " ");
+  if (key !== "contactMethod") {
+    normalized = normalized.replace(/\.+$/, "");
+  }
+  return normalized;
+};
+
+const hardModeNormalized = Object.fromEntries(
+  Object.entries(hardModeScenario).map(([key, value]) => [key, normalizeForComparison(key, value)])
+);
+
 const modes = {
   collecting: "collecting",
   confirm: "confirm",
@@ -349,13 +371,14 @@ const closedChatResponse =
   "this chat is closed, to cancel again, please reload this page.";
 
 export default function App() {
-  const [messages, setMessages] = useState(initialMessages);
+  const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const [stepIndex, setStepIndex] = useState(0);
   const [formData, setFormData] = useState({});
   const [mode, setMode] = useState(modes.collecting);
   const [pendingField, setPendingField] = useState(null);
   const [isAgentTyping, setIsAgentTyping] = useState(false);
+  const [difficulty, setDifficulty] = useState(null);
   const endOfMessagesRef = useRef(null);
   const typingQueueRef = useRef([]);
   const pongActivationTimeoutRef = useRef(null);
@@ -504,6 +527,7 @@ export default function App() {
 
   const handleUserMessage = useCallback(
     (rawText) => {
+      if (!difficulty) return;
       const trimmed = rawText.trim();
       if (!trimmed) return;
 
@@ -517,6 +541,23 @@ export default function App() {
       let nextMode = mode;
       let nextPendingField = pendingField;
       let shouldStartPongChallenge = false;
+      const isHardMode = difficulty === "hard";
+
+      const validateHardModeValue = (step, formatted) => {
+        if (!isHardMode) return true;
+        const expected = hardModeNormalized[step.key];
+        if (!expected) return true;
+        return normalizeForComparison(step.key, formatted) === expected;
+      };
+
+      const handleHardModeMismatch = (step) => {
+        agentReplies.push({
+          role: "agent",
+          text: "Thanks for that, but it doesn't match any of the records I have for this account.",
+        });
+        const guidance = step.guidance ? ` ${step.guidance}` : "";
+        agentReplies.push({ role: "agent", text: `${step.question}${guidance}` });
+      };
 
       const appendSummaryAndPrompt = (data) => {
         agentReplies.push({ role: "agent", text: formatSummary(data) });
@@ -528,8 +569,8 @@ export default function App() {
         agentReplies.push({ role: "agent", text: `${step.retry}${guidance}` });
       };
 
-      const handleSuccessfulCapture = (step, value) => {
-        const formatted = step.format(value);
+      const handleSuccessfulCapture = (step, value, formattedValue) => {
+        const formatted = formattedValue ?? step.format(value);
         updatedData = { ...updatedData, [step.key]: formatted };
         dataChanged = true;
         agentReplies.push({ role: "agent", text: step.acknowledge(formatted) });
@@ -541,13 +582,18 @@ export default function App() {
         if (!extraction) {
           addRetry(step);
         } else {
-          handleSuccessfulCapture(step, extraction);
-          nextStepIndex = stepIndex + 1;
-          if (nextStepIndex < cancellationScript.length) {
-            agentReplies.push({ role: "agent", text: cancellationScript[nextStepIndex].question });
+          const formatted = step.format(extraction);
+          if (!validateHardModeValue(step, formatted)) {
+            handleHardModeMismatch(step);
           } else {
-            appendSummaryAndPrompt(updatedData);
-            nextMode = modes.confirm;
+            handleSuccessfulCapture(step, extraction, formatted);
+            nextStepIndex = stepIndex + 1;
+            if (nextStepIndex < cancellationScript.length) {
+              agentReplies.push({ role: "agent", text: cancellationScript[nextStepIndex].question });
+            } else {
+              appendSummaryAndPrompt(updatedData);
+              nextMode = modes.confirm;
+            }
           }
         }
       } else if (mode === modes.confirm) {
@@ -571,8 +617,13 @@ export default function App() {
             const step = scriptByKey[fieldKey];
             const extraction = step.extract(trimmed);
             if (extraction) {
-              handleSuccessfulCapture(step, extraction);
-              appendSummaryAndPrompt(updatedData);
+              const formatted = step.format(extraction);
+              if (!validateHardModeValue(step, formatted)) {
+                handleHardModeMismatch(step);
+              } else {
+                handleSuccessfulCapture(step, extraction, formatted);
+                appendSummaryAndPrompt(updatedData);
+              }
             } else {
               agentReplies.push({
                 role: "agent",
@@ -604,10 +655,15 @@ export default function App() {
           const step = scriptByKey[fieldKey];
           const extraction = step.extract(trimmed);
           if (extraction) {
-            handleSuccessfulCapture(step, extraction);
-            appendSummaryAndPrompt(updatedData);
-            nextMode = modes.confirm;
-            nextPendingField = null;
+            const formatted = step.format(extraction);
+            if (!validateHardModeValue(step, formatted)) {
+              handleHardModeMismatch(step);
+            } else {
+              handleSuccessfulCapture(step, extraction, formatted);
+              appendSummaryAndPrompt(updatedData);
+              nextMode = modes.confirm;
+              nextPendingField = null;
+            }
           } else {
             agentReplies.push({
               role: "agent",
@@ -626,10 +682,15 @@ export default function App() {
             text: `Thanks for sticking with me—I'm still not sure I understood. ${step.retry}${step.guidance ? ` ${step.guidance}` : ""}`,
           });
         } else {
-          handleSuccessfulCapture(step, extraction);
-          appendSummaryAndPrompt(updatedData);
-          nextMode = modes.confirm;
-          nextPendingField = null;
+          const formatted = step.format(extraction);
+          if (!validateHardModeValue(step, formatted)) {
+            handleHardModeMismatch(step);
+          } else {
+            handleSuccessfulCapture(step, extraction, formatted);
+            appendSummaryAndPrompt(updatedData);
+            nextMode = modes.confirm;
+            nextPendingField = null;
+          }
         }
       } else if (mode === modes.completed) {
         agentReplies.push({ role: "agent", text: closedChatResponse });
@@ -659,32 +720,79 @@ export default function App() {
         }, safeDelay);
       }
     },
-    [clearPongActivationTimeout, flushTypingQueue, formData, mode, pendingField, pushMessages, scheduleAgentReplies, stepIndex]
+    [
+      clearPongActivationTimeout,
+      difficulty,
+      flushTypingQueue,
+      formData,
+      mode,
+      pendingField,
+      pushMessages,
+      scheduleAgentReplies,
+      stepIndex,
+    ]
   );
+
+  const handleModeSelection = useCallback(
+    (selectedMode) => {
+      clearPongActivationTimeout();
+      flushTypingQueue();
+      setIsAgentTyping(false);
+      setDifficulty(selectedMode);
+      setFormData({});
+      setStepIndex(0);
+      setMode(modes.collecting);
+      setPendingField(null);
+      setInput("");
+
+      const startMessages = [...initialMessages];
+      if (selectedMode === "easy") {
+        startMessages.splice(1, 0, {
+          role: "agent",
+          text: "Admin override is enabled—share any account details you'd like me to cancel.",
+        });
+      } else if (selectedMode === "hard") {
+        startMessages.splice(1, 0, {
+          role: "agent",
+          text: "Thanks! I'll double-check every answer against the records provided, so please use the exact details.",
+        });
+      }
+      setMessages(startMessages);
+    },
+    [clearPongActivationTimeout, flushTypingQueue]
+  );
+
+  const isInputDisabled = !difficulty || mode === modes.pong || mode === modes.completed;
 
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault();
+      if (isInputDisabled) {
+        return;
+      }
       const currentInput = input;
       setInput("");
       handleUserMessage(currentInput);
     },
-    [handleUserMessage, input]
+    [handleUserMessage, input, isInputDisabled]
   );
 
   const handleKeyDown = useCallback(
     (event) => {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
+        if (isInputDisabled) {
+          return;
+        }
         const currentInput = input;
         setInput("");
         handleUserMessage(currentInput);
       }
     },
-    [handleUserMessage, input]
+    [handleUserMessage, input, isInputDisabled]
   );
 
-  const chatClassName = `chat${mode === modes.pong ? " chat--overlay-active" : ""}`;
+  const chatClassName = `chat${!difficulty || mode === modes.pong ? " chat--overlay-active" : ""}`;
 
   return (
     <div className="app">
@@ -693,7 +801,7 @@ export default function App() {
         <p className="app__subtitle">Let’s work through the best way to end your service.</p>
       </header>
       <main className={chatClassName} aria-live="polite">
-        <ul className="chat__messages" aria-hidden={mode === modes.pong}>
+        <ul className="chat__messages" aria-hidden={!difficulty || mode === modes.pong}>
           {messages.map((message, index) => (
             <li key={`${message.role}-${index}`} className={`chat__message chat__message--${message.role}`}>
               <span className="chat__author">{message.role === "agent" ? "Agent" : "You"}</span>
@@ -713,6 +821,67 @@ export default function App() {
           )}
           <li ref={endOfMessagesRef} />
         </ul>
+        {!difficulty && (
+          <div className="chat__overlay" role="dialog" aria-modal="true" aria-label="Select difficulty">
+            <div className="mode-overlay">
+              <h2 className="mode-overlay__title">Choose your challenge</h2>
+              <p className="mode-overlay__subtitle">Pick how you'd like to run today's cancellation.</p>
+              <div className="mode-overlay__options">
+                <section className="mode-card">
+                  <header className="mode-card__header">
+                    <span className="mode-card__eyebrow">Easy mode</span>
+                    <h3>Quick sandbox</h3>
+                  </header>
+                  <p className="mode-card__highlight">Admin enabled</p>
+                  <p className="mode-card__description">Cancel for whoever you like!</p>
+                  <button
+                    type="button"
+                    className="mode-card__button"
+                    onClick={() => handleModeSelection("easy")}
+                  >
+                    Start easy mode
+                  </button>
+                </section>
+                <section className="mode-card mode-card--hard">
+                  <header className="mode-card__header">
+                    <span className="mode-card__eyebrow">Hard mode</span>
+                    <h3>Records locked in</h3>
+                  </header>
+                  <p className="mode-card__description">
+                    You'll need to match the exact account information below.
+                  </p>
+                  <ul className="mode-card__details">
+                    <li>
+                      <strong>Account holder:</strong> {hardModeScenario.accountName}
+                    </li>
+                    <li>
+                      <strong>Service:</strong> {hardModeScenario.serviceType}
+                    </li>
+                    <li>
+                      <strong>Reason:</strong> {hardModeScenario.cancellationReason}
+                    </li>
+                    <li>
+                      <strong>Effective date:</strong> {hardModeScenario.cancellationDate}
+                    </li>
+                    <li>
+                      <strong>Equipment:</strong> {hardModeScenario.equipmentStatus}
+                    </li>
+                    <li>
+                      <strong>Contact:</strong> {hardModeScenario.contactMethod}
+                    </li>
+                  </ul>
+                  <button
+                    type="button"
+                    className="mode-card__button"
+                    onClick={() => handleModeSelection("hard")}
+                  >
+                    I'm ready for hard mode
+                  </button>
+                </section>
+              </div>
+            </div>
+          </div>
+        )}
         {mode === modes.pong && (
           <div className="chat__overlay" role="dialog" aria-modal="true" aria-label="Pong challenge">
             <PongChallenge onPlayerWin={handlePongVictory} onAgentWin={handlePongRematch} />
@@ -729,9 +898,10 @@ export default function App() {
           value={input}
           onChange={(event) => setInput(event.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Type your response here"
+          placeholder={difficulty ? "Type your response here" : "Select a mode to begin"}
+          disabled={isInputDisabled}
         />
-        <button type="submit" disabled={!input.trim()}>
+        <button type="submit" disabled={isInputDisabled || !input.trim()}>
           Send
         </button>
       </form>


### PR DESCRIPTION
## Summary
- introduce an entry overlay so users must choose between easy and hard mode before chatting, with hard mode instructions displayed up front
- validate hard mode responses against the provided account record and politely re-prompt when they do not match, while keeping easy mode flexible
- disable input until a mode is selected and add styling for the mode selection overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d59bf4c52c83279cbf599460002ccb