### PR TITLE
Update agent closing message after cancellation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -536,7 +536,7 @@ export default function App() {
         },
         {
           role: "agent",
-          text: "I'll submit the cancellation with those details and send a confirmation to your contact on file. Is there anything else I can do for you today?",
+          text: "I'll submit the cancellation with those details and send a confirmation to your contact on file. If you'd like to make another cancellation, please refresh to connect with a new agent.",
         },
         {
         role: "agent",


### PR DESCRIPTION
## Summary
- update the agent's closing response after completing a cancellation to clarify how to start another request

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d645ae3c3c83279a9625beb6637377