### PR TITLE
Add typing delay to initial agent greetings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1093,9 +1093,16 @@ export default function App() {
           });
         }
       }
-      setMessages(startMessages);
+      setMessages([]);
+      scheduleAgentReplies(startMessages);
     },
-    [baseInitialMessages, clearPongActivationTimeout, flushTypingQueue, hardScenario]
+    [
+      baseInitialMessages,
+      clearPongActivationTimeout,
+      flushTypingQueue,
+      hardScenario,
+      scheduleAgentReplies,
+    ]
   );
 
   const isInputDisabled = !difficulty || mode === modes.pong || mode === modes.completed;


### PR DESCRIPTION
## Summary
- queue the initial agent greeting messages through the typing scheduler
- ensure the greetings display after the typing animation instead of instantly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c53c631c83278b1bd278a5ac2e5c