### PR TITLE
Parse "today" cancellation requests as current date

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -175,13 +175,13 @@ const extractCancellationDate = (input) => {
   const now = new Date();
 
   if (lowered === "now" || /^right now$/.test(lowered)) {
-    return "Today";
+    return formatDate(now);
   }
   if (/asap|soon|immediately/.test(lowered)) {
     return "As soon as possible";
   }
   if (/today/.test(lowered)) {
-    return "Today";
+    return formatDate(now);
   }
   if (/tomorrow/.test(lowered)) {
     const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- format "now"/"today" cancellation inputs as the current date instead of the literal word
- keep the hard mode scenario seed cancellation date as the literal "Today"

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c57e37a0832789fec7f1dc10131b