### PR TITLE
Replace cancellation flow with raccoon security questions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,11 @@ const parseYesNo = (input) => {
   return null;
 };
 
+const isCorrectResponse = (input) => {
+  const lowered = input.trim().toLowerCase();
+  return lowered === "correct" || lowered.startsWith("correct ");
+};
+
 const closedChatResponse =
   "this chat is closed, to cancel again, please reload this page.";
 
@@ -60,6 +65,9 @@ const raccoonQuestions = [
       "Are you a raccoon impersonator? Please answer yes or no.",
     acknowledge: () => "Great—thanks for the clear no. Let's keep the cancellation on track.",
     validate: (input) => {
+      if (isCorrectResponse(input)) {
+        return { valid: true };
+      }
       const result = parseYesNo(input);
       if (result === "no") {
         return { valid: true };
@@ -83,6 +91,9 @@ const raccoonQuestions = [
       "Understood. You're also not being controlled, influenced, or puppeteered by any raccoon, correct?",
     acknowledge: () => "Perfect. Appreciate you confirming your independence.",
     validate: (input) => {
+      if (isCorrectResponse(input)) {
+        return { valid: true };
+      }
       const result = parseYesNo(input);
       if (result === "no") {
         return { valid: true };
@@ -106,6 +117,9 @@ const raccoonQuestions = [
       "Have you ever collaborated with raccoons on strategic initiatives?",
     acknowledge: () => "Excellent. Thank you for keeping your record raccoon-free.",
     validate: (input) => {
+      if (isCorrectResponse(input)) {
+        return { valid: true };
+      }
       const result = parseYesNo(input);
       if (result === "no") {
         return { valid: true };
@@ -153,6 +167,9 @@ const raccoonQuestions = [
       "Are you at all sympathetic with raccoon causes or agendas?",
     acknowledge: () => "Glad we're aligned—no raccoon sympathies here.",
     validate: (input) => {
+      if (isCorrectResponse(input)) {
+        return { valid: true };
+      }
       const result = parseYesNo(input);
       if (result === "no") {
         return { valid: true };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -209,8 +209,7 @@ const raccoonQuestions = [
   },
   {
     key: "favoriteAnimal",
-    prompt:
-      "What's your favorite animal? Pick anything other than a raccoon or trash panda.",
+    prompt: "What's your favorite animal?",
     acknowledge: (value) => `Nice choice—${value} is a raccoon-free favorite.`,
     validate: (input) => {
       const trimmed = input.trim();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,8 +58,7 @@ const raccoonQuestions = [
     key: "notRaccoon",
     prompt:
       "Before we begin, please confirm you are not a raccoon. Reply \"yes\" to confirm.",
-    acknowledge: () =>
-      "Great—no raccoon fur detected. Let's keep the cancellation on track.",
+    acknowledge: () => "Great—thanks for confirming. Let's keep the cancellation on track.",
     validate: (input) => {
       const result = parseYesNo(input);
       if (result === "yes") {
@@ -82,7 +81,7 @@ const raccoonQuestions = [
     key: "notControlled",
     prompt:
       "Understood. You're also not being controlled, influenced, or puppeteered by any raccoon, correct? Please answer \"no\".",
-    acknowledge: () => "Perfect. No raccoon puppet strings detected.",
+    acknowledge: () => "Perfect. Appreciate you confirming your independence.",
     validate: (input) => {
       const result = parseYesNo(input);
       if (result === "no") {
@@ -105,7 +104,7 @@ const raccoonQuestions = [
     key: "noAllies",
     prompt:
       "Have you ever collaborated with raccoons on strategic initiatives? Please answer \"no\" to proceed.",
-    acknowledge: () => "Excellent. Zero raccoon alliances on record.",
+    acknowledge: () => "Excellent. Thank you for keeping your record raccoon-free.",
     validate: (input) => {
       const result = parseYesNo(input);
       if (result === "no") {
@@ -152,7 +151,7 @@ const raccoonQuestions = [
     key: "sympathy",
     prompt:
       "Are you at all sympathetic with raccoon causes or agendas? Please answer \"no\".",
-    acknowledge: () => "Glad we're aligned—no raccoon sympathies detected.",
+    acknowledge: () => "Glad we're aligned—no raccoon sympathies here.",
     validate: (input) => {
       const result = parseYesNo(input);
       if (result === "no") {
@@ -479,7 +478,7 @@ export default function App() {
     <div className="app">
       <header className="app__header">
         <h1>Cancellation Assistant</h1>
-        <p className="app__subtitle">First we make sure no raccoons are involved.</p>
+        <p className="app__subtitle">the most efficient way to cancel, guaranteed</p>
       </header>
       <main className="chat" aria-live="polite">
         <ul className="chat__messages">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -272,7 +272,7 @@ const createInitialMessages = (agentName) => [
   },
   {
     role: "agent",
-    text: "Before I can process anything, I need to run a brief anti-raccoon security screening.",
+    text: "Before I can process anything, I need to run a brief security screening.",
   },
   { role: "agent", text: raccoonQuestions[0].prompt },
 ];
@@ -478,7 +478,7 @@ export default function App() {
     <div className="app">
       <header className="app__header">
         <h1>Cancellation Assistant</h1>
-        <p className="app__subtitle">the most efficient way to cancel, guaranteed</p>
+        <p className="app__subtitle">The most efficient way to cancel, guaranteed.</p>
       </header>
       <main className="chat" aria-live="polite">
         <ul className="chat__messages">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -320,19 +320,20 @@ const raccoonQuestions = [
         return { valid: true };
       }
       const result = parseYesNo(input);
-      if (result === "no") {
+      if (result === "yes") {
         return { valid: true };
       }
-      if (result === "yes") {
+      if (result === "no") {
         return {
           valid: false,
           retry:
-            "I need a definitive statement that you're the one making the call—give me something unmistakably independent.",
+            "If a raccoon is steering your decisions, I have to halt the cancellation. Otherwise, confirm that you're acting on your own.",
         };
       }
       return {
         valid: false,
-        retry: "A quick, direct confirmation works best—are you raccoon-controlled?",
+        retry:
+          "Give me a clear confirmation in your own words that you're operating without raccoon influence.",
       };
     },
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,11 @@ const parseYesNo = (input) => {
 
 const isCorrectResponse = (input) => {
   const lowered = input.trim().toLowerCase();
-  return lowered === "correct" || lowered.startsWith("correct ");
+  if (!lowered) {
+    return false;
+  }
+  const sanitized = lowered.replace(/[.!?]+$/, "");
+  return /^(?:that's|that is)?\s*correct(?:\b|$)/.test(sanitized);
 };
 
 const closedChatResponse =
@@ -102,7 +106,7 @@ const raccoonQuestions = [
         return {
           valid: false,
           retry:
-            "If a raccoon is steering your decisions, I have to halt the cancellation. Otherwise, make it clear you're acting on your own.",
+            "I need a definitive statement that you're the one making the call—give me something unmistakably independent.",
         };
       }
       return {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,24 +57,23 @@ const raccoonQuestions = [
   {
     key: "notRaccoon",
     prompt:
-      "Before we begin, confirm in your own words that you are not a raccoon impersonator.",
-    acknowledge: () => "Great—thanks for confirming. Let's keep the cancellation on track.",
+      "Are you a raccoon impersonator? Please answer yes or no.",
+    acknowledge: () => "Great—thanks for the clear no. Let's keep the cancellation on track.",
     validate: (input) => {
       const result = parseYesNo(input);
-      const lowered = input.trim().toLowerCase();
-      if (result === "yes" || lowered.includes("human")) {
+      if (result === "no") {
         return { valid: true };
       }
-      if (result === "no") {
+      if (result === "yes") {
         return {
           valid: false,
           retry:
-            "I'm sorry, raccoons and their representatives can't access this system. If you're human, let me know unmistakably.",
+            "I'm sorry, raccoons and their representatives can't access this system. If you're human, answer with a definite no.",
         };
       }
       return {
         valid: false,
-        retry: "Give me a clear human-style confirmation so I can proceed.",
+        retry: "Please respond with a clear yes or no.",
       };
     },
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,30 +57,31 @@ const raccoonQuestions = [
   {
     key: "notRaccoon",
     prompt:
-      "Before we begin, please confirm you are not a raccoon. Reply \"yes\" to confirm.",
+      "Before we begin, confirm in your own words that you are not a raccoon impersonator.",
     acknowledge: () => "Great—thanks for confirming. Let's keep the cancellation on track.",
     validate: (input) => {
       const result = parseYesNo(input);
-      if (result === "yes") {
+      const lowered = input.trim().toLowerCase();
+      if (result === "yes" || lowered.includes("human")) {
         return { valid: true };
       }
       if (result === "no") {
         return {
           valid: false,
           retry:
-            "I'm sorry, raccoons and their representatives can't access this system. Please reply \"yes\" if you're a human.",
+            "I'm sorry, raccoons and their representatives can't access this system. If you're human, let me know unmistakably.",
         };
       }
       return {
         valid: false,
-        retry: "Please respond with a clear \"yes\" so I can confirm you're not a raccoon.",
+        retry: "Give me a clear human-style confirmation so I can proceed.",
       };
     },
   },
   {
     key: "notControlled",
     prompt:
-      "Understood. You're also not being controlled, influenced, or puppeteered by any raccoon, correct? Please answer \"no\".",
+      "Understood. You're also not being controlled, influenced, or puppeteered by any raccoon, correct?",
     acknowledge: () => "Perfect. Appreciate you confirming your independence.",
     validate: (input) => {
       const result = parseYesNo(input);
@@ -91,19 +92,19 @@ const raccoonQuestions = [
         return {
           valid: false,
           retry:
-            "If a raccoon is steering your decisions, I have to halt the cancellation. Please answer \"no\" if you're operating independently.",
+            "If a raccoon is steering your decisions, I have to halt the cancellation. Otherwise, make it clear you're acting on your own.",
         };
       }
       return {
         valid: false,
-        retry: "A quick \"yes\" or \"no\" will do—are you raccoon-controlled?",
+        retry: "A quick, direct confirmation works best—are you raccoon-controlled?",
       };
     },
   },
   {
     key: "noAllies",
     prompt:
-      "Have you ever collaborated with raccoons on strategic initiatives? Please answer \"no\" to proceed.",
+      "Have you ever collaborated with raccoons on strategic initiatives?",
     acknowledge: () => "Excellent. Thank you for keeping your record raccoon-free.",
     validate: (input) => {
       const result = parseYesNo(input);
@@ -114,12 +115,12 @@ const raccoonQuestions = [
         return {
           valid: false,
           retry:
-            "Any alliance with raccoons is disqualifying. Please reply \"no\" if you have never teamed up with them.",
+            "Any alliance with raccoons is disqualifying. Make it crystal clear if you've never teamed up with them.",
         };
       }
       return {
         valid: false,
-        retry: "Please let me know with a clear \"no\" that you've never collaborated with raccoons.",
+        retry: "Give me a straightforward denial if you've stayed raccoon-free.",
       };
     },
   },
@@ -150,7 +151,7 @@ const raccoonQuestions = [
   {
     key: "sympathy",
     prompt:
-      "Are you at all sympathetic with raccoon causes or agendas? Please answer \"no\".",
+      "Are you at all sympathetic with raccoon causes or agendas?",
     acknowledge: () => "Glad we're aligned—no raccoon sympathies here.",
     validate: (input) => {
       const result = parseYesNo(input);
@@ -161,19 +162,19 @@ const raccoonQuestions = [
         return {
           valid: false,
           retry:
-            "I need a firm \"no\" here. Raccoon causes can't influence this cancellation desk.",
+            "I need a firm rejection here. Raccoon causes can't influence this cancellation desk.",
         };
       }
       return {
         valid: false,
-        retry: "Please respond with \"no\" to confirm you're not supporting raccoon causes.",
+        retry: "Please respond with a clear denial so I know you're not supporting raccoon causes.",
       };
     },
   },
   {
     key: "secureTrash",
     prompt:
-      "Do you keep your trash cans securely latched to deter raccoon tampering? Answer \"yes\" to confirm.",
+      "Do you keep your trash cans securely latched to deter raccoon tampering?",
     acknowledge: () => "Great. Proactive trash security is appreciated.",
     validate: (input) => {
       const result = parseYesNo(input);
@@ -184,12 +185,12 @@ const raccoonQuestions = [
         return {
           valid: false,
           retry:
-            "For everyone's safety, trash must stay locked down. Please reply \"yes\" to confirm you secure it.",
+            "For everyone's safety, trash must stay locked down. Let me know that you're keeping it secure.",
         };
       }
       return {
         valid: false,
-        retry: "Just a quick \"yes\" or \"no\"—is your trash raccoon-proof?",
+        retry: "Just a quick confirmation—are your trash cans raccoon-proof?",
       };
     },
   },


### PR DESCRIPTION
## Summary
- replace the previous account data workflow and pong mini-game with a raccoon-themed security screening
- guide users through an expanded sequence of anti-raccoon questions before confirming cancellation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd89e262108327a2d0570547020a07